### PR TITLE
Update example code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $client->setTimeout(30);
 $service = new \Adyen\Service\Checkout($client);
 
 $json = '{
-      "card": {
+      "paymentMethod": {
         "encryptedCardNumber": "test_4111111111111111",
         "encryptedExpiryMonth": "test_03",
         "encryptedExpiryYear": "test_2030",


### PR DESCRIPTION
encryptedCardNumber does not exist under the card object. Instead, use paymentMethod for successful payments.

**Description**
When using the encrypted card fields, the `card` json object will cause an error. 

**Tested scenarios**
Tested example code as-is. Received 
`Structure of card contains the following unknown fields: [encryptedCardNumber, encryptedSecurityCode, encryptedExpiryYear, encryptedExpiryMonth, type]`

Changing to paymentMethod fixed the issue. 